### PR TITLE
Update malloc.c

### DIFF
--- a/32bit/malloc.c
+++ b/32bit/malloc.c
@@ -66,6 +66,7 @@ void* malloc(unsigned size)
 			&&(header->size <= size + HEADER_SIZE *2))
 		{
 			header->type = HEAP_BLOCK_USED;
+			return ADDR_ADD(header,HEADER_SIZE);//after mark this block as used,you have to return immediately
 		}
 
 		if (header->size > size + HEADER_SIZE*2)


### PR DESCRIPTION
在堆管理的malloc函数中，有个逻辑分支错误（看了下原著，也有同样的错误），在遇到一个空闲块大于请求大小+头大小，并且该空闲空间减去请求大小+头大小的剩余空间不能在形成一个空闲块的时候，按逻辑将此整个空闲块标记为使用中并返回此块的地址，然而在代码中只有标记，没有返回
可能造成的后果：标记为使用而未返回之，将会造成内存泄漏